### PR TITLE
Port to wx.Dialog so plugin works on MacOS

### DIFF
--- a/plugins/schematic_blocks_pluging_action.py
+++ b/plugins/schematic_blocks_pluging_action.py
@@ -22,8 +22,9 @@ class SchematicBlocksPluging(pcbnew.ActionPlugin):
     def Run(self):
         # The entry function of the plugin that is executed on user action
         print("Hello World")
-        app = SchematicBlockSaverPlugin(False)
-        app.MainLoop()
+        dialog = SchematicBlockSaverPlugin(None)
+        dialog.Center()
+        dialog.Show()
         # pcbnew.Refresh()
         
 
@@ -34,16 +35,18 @@ class SchematicBlocksPluging(pcbnew.ActionPlugin):
 
 
 
-class SchematicBlockSaverPlugin(wx.App):
-    def OnInit(self):
-        self.frame = SchematicBlockSaverFrame(None, title="Schematic Block Saver",size=(400, 600))
-        self.SetTopWindow(self.frame)
-        self.frame.Show()
-        return True
 
-class SchematicBlockSaverFrame(wx.Frame):
-    def __init__(self, *args, **kwargs):
-        super(SchematicBlockSaverFrame, self).__init__(*args, **kwargs)
+class SchematicBlockSaverPlugin(wx.Dialog):
+    def __init__(self, parent):
+        wx.Dialog.__init__(
+            self,
+            parent,
+            id=wx.ID_ANY,
+            title="Schematic Block Saver",
+            pos=wx.DefaultPosition,
+            size=wx.Size(400, 600),
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | wx.MAXIMIZE_BOX,
+        )
 
         self.InitUI()
 


### PR DESCRIPTION
Fixes #6 on MacOS using the suggestion to use `wx.Dialog` instead of `wx.App`.

I only have the capability to test on MacOS, but it works well! The format here seems to follow the conventions I see in other KiCad plugins of the same nature. Please let me know if there's more I can do here; I believe this is using the wxWidgets idioms properly, but I'm overall pretty new to that ecosystem.

Proof:
<img width="512" alt="image" src="https://github.com/user-attachments/assets/94b68951-e885-4aa1-9aa3-c62608c083a5">
